### PR TITLE
Add instrumentation-aware professional test suite

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,6 +1,18 @@
 import argparse
 from logger import LogBus, Report
-from engine_tests import uci, burst, endurance, threads, multipv, instances, fuzz, pgnreplay
+from engine_tests import (
+    uci,
+    burst,
+    endurance,
+    threads,
+    multipv,
+    instances,
+    fuzz,
+    pgnreplay,
+    asmdebug,
+    prosuite,
+)
+from instrumentation import detect
 
 def main():
     ap = argparse.ArgumentParser(description="CESTT — CLI")
@@ -12,21 +24,48 @@ def main():
     ap.add_argument("--instances", type=int, default=4)
     ap.add_argument("--per-instance", type=int, default=50)
     ap.add_argument("--pgn-dir", default="")
-    ap.add_argument("--tests", default="uci,burst,threads,multipv", help="comma list: uci,burst,endurance,threads,multipv,instances,fuzz,pgn")
+    default_tests = "uci,burst,threads,multipv"
+    ap.add_argument(
+        "--tests",
+        default=default_tests,
+        help="comma list: uci,burst,endurance,threads,multipv,instances,fuzz,pgn,asm,pro (use 'auto' for defaults)",
+    )
     args = ap.parse_args()
 
     bus = LogBus()
-    rep = Report(args.engine)
-    selected = {t.strip() for t in args.tests.split(",") if t.strip()}
+    profile = detect(args.engine)
+    if profile.manifest:
+        bus.log(f"[instrumentation] detected {profile.describe()}")
+    elif profile.error:
+        bus.log(f"[instrumentation] manifest error: {profile.error}")
+    else:
+        bus.log("[instrumentation] no instrumentation manifest found")
 
-    if "uci"       in selected: uci.run(bus, rep, args.engine, movetime=args.movetime)
-    if "burst"     in selected: burst.run(bus, rep, args.engine, count=args.burst, movetime=args.movetime)
-    if "endurance" in selected: endurance.run(bus, rep, args.engine, duration_s=args.duration, movetime=args.movetime)
-    if "threads"   in selected: threads.run(bus, rep, args.engine, movetime=args.movetime, max_threads=args.threads_max)
-    if "multipv"   in selected: multipv.run(bus, rep, args.engine, movetime=args.movetime, multipv=4)
-    if "instances" in selected: instances.run(bus, rep, args.engine, instances=args.instances, per_instance=args.per_instance, movetime=args.movetime)
-    if "fuzz"      in selected: fuzz.run(bus, rep, args.engine, seconds=10)
-    if "pgn"       in selected and args.pgn_dir: pgnreplay.run(bus, rep, args.engine, pgn_dir=args.pgn_dir, movetime=args.movetime, max_games=200)
+    rep = Report(args.engine, instrumentation=profile)
+
+    raw_tests = args.tests.strip()
+    if raw_tests.lower() == "auto":
+        selected = set(default_tests.split(","))
+    else:
+        selected = {t.strip() for t in raw_tests.split(",") if t.strip()}
+
+    if profile.supports_assembly_debug() and (raw_tests.lower() == "auto" or raw_tests == default_tests):
+        bus.log("[instrumentation] enabling assembly diagnostics")
+        selected.add("asm")
+    if profile.supports_professional_suite() and (raw_tests.lower() == "auto" or raw_tests == default_tests):
+        bus.log("[instrumentation] enabling professional suite")
+        selected.add("pro")
+
+    if "uci"       in selected: uci.run(bus, rep, args.engine, movetime=args.movetime, instrumentation=profile)
+    if "burst"     in selected: burst.run(bus, rep, args.engine, count=args.burst, movetime=args.movetime, instrumentation=profile)
+    if "endurance" in selected: endurance.run(bus, rep, args.engine, duration_s=args.duration, movetime=args.movetime, instrumentation=profile)
+    if "threads"   in selected: threads.run(bus, rep, args.engine, movetime=args.movetime, max_threads=args.threads_max, instrumentation=profile)
+    if "multipv"   in selected: multipv.run(bus, rep, args.engine, movetime=args.movetime, multipv=4, instrumentation=profile)
+    if "instances" in selected: instances.run(bus, rep, args.engine, instances=args.instances, per_instance=args.per_instance, movetime=args.movetime, instrumentation=profile)
+    if "fuzz"      in selected: fuzz.run(bus, rep, args.engine, seconds=10, instrumentation=profile)
+    if "pgn"       in selected and args.pgn_dir: pgnreplay.run(bus, rep, args.engine, pgn_dir=args.pgn_dir, movetime=args.movetime, max_games=200, instrumentation=profile)
+    if "asm"       in selected: asmdebug.run(bus, rep, args.engine, instrumentation=profile)
+    if "pro"       in selected: prosuite.run(bus, rep, args.engine, movetime=args.movetime, instrumentation=profile)
 
     rep.finish()
     print(rep.to_json())

--- a/engine_tests/asmdebug.py
+++ b/engine_tests/asmdebug.py
@@ -1,0 +1,59 @@
+import time
+from core import EngineRunner
+from instrumentation import InstrumentationProfile
+
+
+def run(logger, report, path, instrumentation: InstrumentationProfile = None, capture_seconds: float = 1.5):
+    manifest_path = None
+    if instrumentation and instrumentation.manifest_path:
+        manifest_path = str(instrumentation.manifest_path)
+    report.add_test("assembly_debug", capture_seconds=capture_seconds, manifest=manifest_path)
+
+    if not instrumentation or not instrumentation.supports_assembly_debug():
+        logger.log("[ASM] instrumentation package not detected — skipping assembly diagnostics")
+        if instrumentation and instrumentation.error:
+            report.data.setdefault("notes", []).append(f"asm_debug manifest error: {instrumentation.error}")
+        return
+
+    logger.log(f"[ASM] instrumentation → {instrumentation.describe()}")
+    if instrumentation.assembly_map:
+        preview = instrumentation.assembly_map[:5]
+        for entry in preview:
+            sym = entry.get("symbol") or entry.get("name") or "?"
+            addr = entry.get("address") or entry.get("offset") or "?"
+            size = entry.get("size") or entry.get("bytes")
+            logger.log(f"[ASM] breakpoint {sym} @ {addr} size={size}")
+        if len(instrumentation.assembly_map) > len(preview):
+            logger.log(f"[ASM] … {len(instrumentation.assembly_map) - len(preview)} more entries")
+
+    try:
+        with EngineRunner(path, instrumentation=instrumentation) as er:
+            # Re-issue commands with logging to show activity.
+            instrumentation.activate(er, logger=logger)
+            probe_cmd = instrumentation.probes.get("asm_state") if instrumentation.probes else None
+            if probe_cmd:
+                try:
+                    logger.log(f"[ASM] requesting probe: {probe_cmd}")
+                    er.send_command(probe_cmd)
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.log(f"[ASM] probe command failed: {exc!r}")
+            time.sleep(min(0.5, capture_seconds))
+    except Exception as exc:
+        logger.log(f"[ASM] engine session failed: {exc!r}")
+        report.data.setdefault("notes", []).append(f"asm_debug error: {exc!r}")
+        return
+
+    trace = instrumentation.capture_trace_preview()
+    if trace:
+        lines = [ln for ln in trace.splitlines() if ln.strip()][:6]
+        if lines:
+            logger.log("[ASM] trace preview:")
+            for line in lines:
+                logger.log(f"[ASM] | {line}")
+        else:
+            logger.log("[ASM] trace file contained no printable lines")
+    else:
+        logger.log("[ASM] no trace data available")
+
+    for warning in instrumentation.warnings:
+        logger.log(f"[ASM] warning: {warning}")

--- a/engine_tests/burst.py
+++ b/engine_tests/burst.py
@@ -1,8 +1,9 @@
 from core import EngineRunner, random_legal_fen
 
-def run(logger, report, path, count=200, movetime=0.02):
+
+def run(logger, report, path, count=200, movetime=0.02, instrumentation=None):
     report.add_test("burst", count=count, movetime=movetime)
-    with EngineRunner(path) as er:
+    with EngineRunner(path, instrumentation=instrumentation) as er:
         nodes_total = 0
         for i in range(count):
             fen = random_legal_fen(10)

--- a/engine_tests/endurance.py
+++ b/engine_tests/endurance.py
@@ -1,12 +1,13 @@
 import time
 from core import EngineRunner, random_legal_fen
 
-def run(logger, report, path, duration_s=60, movetime=0.1):
+
+def run(logger, report, path, duration_s=60, movetime=0.1, instrumentation=None):
     report.add_test("endurance", duration_s=duration_s, movetime=movetime)
     t0 = time.time()
     iters = 0
     cpu_peak, rss_peak = 0.0, 0
-    with EngineRunner(path) as er:
+    with EngineRunner(path, instrumentation=instrumentation) as er:
         while time.time() - t0 < duration_s:
             fen = random_legal_fen(14)
             cp, _ = er.analyse_cp(fen, movetime=movetime)

--- a/engine_tests/multipv.py
+++ b/engine_tests/multipv.py
@@ -1,8 +1,9 @@
 from core import EngineRunner
 import chess
 
-def run(logger, report, path, movetime=0.25, multipv=4):
+
+def run(logger, report, path, movetime=0.25, multipv=4, instrumentation=None):
     report.add_test("multipv", movetime=movetime, multipv=multipv)
-    with EngineRunner(path, multipv=multipv) as er:
+    with EngineRunner(path, multipv=multipv, instrumentation=instrumentation) as er:
         cp, info = er.analyse_cp(chess.STARTING_FEN, movetime=movetime)
         logger.log(f"[MultiPV] cp={cp} info_keys={list(info.keys())}")

--- a/engine_tests/pgnreplay.py
+++ b/engine_tests/pgnreplay.py
@@ -9,13 +9,13 @@ def _stream_games(paths):
                 if not g: break
                 yield p, g
 
-def run(logger, report, path, pgn_dir, movetime=0.05, max_games=200):
+def run(logger, report, path, pgn_dir, movetime=0.05, max_games=200, instrumentation=None):
     files = glob.glob(os.path.join(pgn_dir, "*.pgn"))
     report.add_test("pgn_replay", dir=pgn_dir, movetime=movetime, max_games=max_games, files=len(files))
     if not files:
         logger.log("[PGN] no files found"); return
     count = 0
-    with EngineRunner(path) as er:
+    with EngineRunner(path, instrumentation=instrumentation) as er:
         for fpath, game in _stream_games(files):
             board = game.board()
             for mv in game.mainline_moves():

--- a/engine_tests/prosuite.py
+++ b/engine_tests/prosuite.py
@@ -1,0 +1,222 @@
+import chess
+from core import EngineRunner, random_legal_fen
+from instrumentation import InstrumentationProfile
+
+
+DEFAULT_TACTICAL_SUITE = [
+    {
+        "label": "King's Gambit Pressure",
+        "fen": "rnbqkbnr/pppp1ppp/8/4p3/2B1P3/8/PPPP1PPP/RNBQK1NR b KQkq - 1 2",
+        "movetime": 0.6,
+    },
+    {
+        "label": "Closed centre grind",
+        "fen": "rnbq1rk1/ppp2ppp/3bpn2/3p4/3P4/2N1PN2/PP3PPP/R1BQKB1R w KQ - 0 8",
+        "movetime": 0.6,
+    },
+    {
+        "label": "Technical rook ending",
+        "fen": "8/5pk1/5np1/1p6/pP3P2/P1P2K1P/6P1/8 w - - 0 1",
+        "movetime": 0.6,
+    },
+]
+
+DEFAULT_STABILITY = {
+    "samples": 6,
+    "movetime": 0.35,
+    "max_cp_delta": 45,
+    "max_plies": 18,
+}
+
+
+def _load_suite(definition, fallback):
+    if not definition:
+        return list(fallback), {}
+    if isinstance(definition, dict):
+        positions = definition.get("positions")
+        if not isinstance(positions, list):
+            positions = fallback
+        opts = {k: v for k, v in definition.items() if k != "positions"}
+        return list(positions), opts
+    if isinstance(definition, list):
+        return list(definition), {}
+    return list(fallback), {}
+
+
+def _normalise_entry(entry):
+    if isinstance(entry, str):
+        return {"fen": entry}
+    if isinstance(entry, dict):
+        return dict(entry)
+    return {}
+
+
+def _expected_moves(entry, board: chess.Board):
+    moves = []
+    candidates = []
+    for key in ("best", "expected_move", "expected_moves"):
+        value = entry.get(key)
+        if isinstance(value, (list, tuple, set)):
+            candidates.extend(value)
+        elif value is not None:
+            candidates.append(value)
+    result = []
+    for item in candidates:
+        if item is None:
+            continue
+        text = str(item).strip()
+        if not text:
+            continue
+        try:
+            move = board.parse_san(text)
+            result.append(move.uci())
+            continue
+        except Exception:
+            pass
+        if len(text) in (4, 5) and text[0].isalpha():
+            result.append(text)
+    return result
+
+
+def run(logger, report, path, movetime=0.4, instrumentation: InstrumentationProfile = None):
+    manifest_path = None
+    if instrumentation and instrumentation.manifest_path:
+        manifest_path = str(instrumentation.manifest_path)
+
+    raw_suite, suite_opts = _load_suite(
+        instrumentation.get_suite("tactical") if instrumentation else None,
+        DEFAULT_TACTICAL_SUITE,
+    )
+    tactical_entries = []
+    for item in raw_suite:
+        norm = _normalise_entry(item)
+        if norm.get("fen"):
+            tactical_entries.append(norm)
+    if not tactical_entries:
+        for item in DEFAULT_TACTICAL_SUITE:
+            norm = _normalise_entry(item)
+            if norm.get("fen"):
+                tactical_entries.append(norm)
+
+    stability_conf = dict(DEFAULT_STABILITY)
+    if instrumentation:
+        stability_def = instrumentation.get_suite("stability")
+        if isinstance(stability_def, dict):
+            stability_conf.update(stability_def)
+
+    samples = int(max(1, stability_conf.get("samples", DEFAULT_STABILITY["samples"])))
+
+    report.add_test(
+        "professional_suite",
+        movetime=movetime,
+        manifest=manifest_path,
+        tactical_positions=len(tactical_entries),
+        stability_samples=samples,
+    )
+
+    if not instrumentation or not instrumentation.supports_professional_suite():
+        logger.log("[PRO] instrumentation package missing — professional suite locked")
+        if instrumentation and instrumentation.error:
+            report.data.setdefault("notes", []).append(f"professional suite manifest error: {instrumentation.error}")
+        return
+
+    analysis_threads = int(suite_opts.get("threads", 1)) if suite_opts else 1
+    analysis_hash = int(suite_opts.get("hash", 256)) if suite_opts else 256
+    analysis_multipv = int(suite_opts.get("multipv", 3)) if suite_opts else 3
+    base_movetime = float(suite_opts.get("movetime", movetime)) if suite_opts else float(movetime)
+
+    try:
+        with EngineRunner(
+            path,
+            threads=max(1, analysis_threads),
+            hash_mb=max(32, analysis_hash),
+            multipv=max(1, analysis_multipv),
+            instrumentation=instrumentation,
+        ) as er:
+            instrumentation.activate(er, logger=logger)
+
+            passed = 0
+            for idx, entry in enumerate(tactical_entries, 1):
+                fen = entry.get("fen")
+                if not fen:
+                    continue
+                board = chess.Board(fen)
+                label = entry.get("label") or entry.get("name") or f"pos#{idx}"
+                entry_movetime = float(entry.get("movetime", base_movetime))
+                depth = entry.get("depth")
+                cp, info = er.analyse_cp(fen, movetime=entry_movetime, depth=depth)
+                pv = info.get("pv") or []
+                pv_moves = []
+                try:
+                    pv_moves = [mv.uci() if hasattr(mv, "uci") else str(mv) for mv in pv]
+                except Exception:
+                    pv_moves = [str(mv) for mv in pv]
+                best_move = pv_moves[0] if pv_moves else None
+                nodes = info.get("nodes")
+                speed = None
+                if nodes and entry_movetime > 0:
+                    speed = int(nodes / max(entry_movetime, 1e-6))
+                logger.log(
+                    f"[PRO] tactical {label}: cp={cp} nodes={nodes} nps={speed} pv={pv_moves[:3]}"
+                )
+
+                expected_candidates = _expected_moves(entry, board)
+                success = True
+                if expected_candidates:
+                    if best_move in expected_candidates:
+                        logger.log(f"[PRO] ✓ {label} expected move matched ({best_move})")
+                    else:
+                        logger.log(
+                            f"[PRO] ✗ {label} expected {expected_candidates} got {best_move}"
+                        )
+                        success = False
+
+                cp_range = entry.get("cp_range") or entry.get("expected_cp_range")
+                if cp_range and isinstance(cp_range, (list, tuple)) and len(cp_range) == 2:
+                    low, high = float(cp_range[0]), float(cp_range[1])
+                    if not (low <= cp <= high):
+                        logger.log(
+                            f"[PRO] ✗ {label} eval {cp} outside range [{low}, {high}]"
+                        )
+                        success = False
+
+                if success:
+                    passed += 1
+                else:
+                    report.data.setdefault("notes", []).append(f"tactical miss: {label}")
+
+            if tactical_entries:
+                logger.log(
+                    f"[PRO] tactical summary: {passed}/{len(tactical_entries)} matched expectations"
+                )
+
+            stability_failures = 0
+            stability_movetime = float(stability_conf.get("movetime", base_movetime))
+            max_cp_delta = float(stability_conf.get("max_cp_delta", DEFAULT_STABILITY["max_cp_delta"]))
+            max_plies = int(stability_conf.get("max_plies", DEFAULT_STABILITY["max_plies"]))
+
+            for i in range(samples):
+                fen = random_legal_fen(max(4, max_plies))
+                cp1, _ = er.analyse_cp(fen, movetime=stability_movetime)
+                cp2, _ = er.analyse_cp(fen, movetime=stability_movetime)
+                delta = abs(cp1 - cp2)
+                logger.log(
+                    f"[PRO] stability {i+1}/{samples}: Δcp={delta} cp1={cp1} cp2={cp2}"
+                )
+                if delta > max_cp_delta:
+                    stability_failures += 1
+            if stability_failures:
+                report.data.setdefault("notes", []).append(
+                    f"stability drift: {stability_failures}/{samples} over threshold"
+                )
+            logger.log(
+                f"[PRO] stability summary: {samples - stability_failures}/{samples} within Δcp≤{max_cp_delta}"
+            )
+
+    except Exception as exc:
+        logger.log(f"[PRO] professional suite failed: {exc!r}")
+        report.data.setdefault("notes", []).append(f"professional suite error: {exc!r}")
+        return
+
+    for warning in instrumentation.warnings:
+        logger.log(f"[PRO] warning: {warning}")

--- a/engine_tests/threads.py
+++ b/engine_tests/threads.py
@@ -1,13 +1,14 @@
 from core import EngineRunner
 import chess, time
 
-def run(logger, report, path, movetime=0.2, max_threads=8):
+
+def run(logger, report, path, movetime=0.2, max_threads=8, instrumentation=None):
     report.add_test("threads_scaling", movetime=movetime, max_threads=max_threads)
     results = []
     for th in [1,2,4,8]:
         if th > max_threads: break
         t0 = time.time()
-        with EngineRunner(path, threads=th) as er:
+        with EngineRunner(path, threads=th, instrumentation=instrumentation) as er:
             cp, info = er.analyse_cp(chess.STARTING_FEN, movetime=movetime)
             nodes = int(info.get("nodes", 0))
             dt = time.time()-t0

--- a/engine_tests/uci.py
+++ b/engine_tests/uci.py
@@ -1,8 +1,9 @@
 from core import EngineRunner
 import chess
 
-def run(logger, report, path, movetime=0.05):
+
+def run(logger, report, path, movetime=0.05, instrumentation=None):
     report.add_test("uci_handshake", movetime=movetime)
-    with EngineRunner(path) as er:
+    with EngineRunner(path, instrumentation=instrumentation) as er:
         cp, _ = er.analyse_cp(chess.STARTING_FEN, movetime=movetime)
         logger.log(f"[UCI] startpos movetime={int(movetime*1000)}ms → cp={cp}")

--- a/instrumentation.py
+++ b/instrumentation.py
@@ -1,0 +1,222 @@
+"""Instrumentation detection and activation helpers for CESTT.
+
+This module enables the toolkit to detect whether it was built alongside a
+dedicated instrumentation package when the target chess engine was compiled.
+If such a package is found a manifest file will describe the additional
+capabilities that can be unlocked (assembly debug hooks, professional stress
+suites, trace capture, ...).  The GUI/CLI will leverage this information to
+expose advanced tests automatically.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+
+def _iter_candidates(engine_path: Optional[str]) -> Iterable[Path]:
+    """Yield possible manifest locations for *engine_path*.
+
+    The instrumentation bundle may drop the manifest using different naming
+    schemes.  We also honour the ``CESTT_MANIFEST`` environment variable for
+    custom setups.
+    """
+
+    env_path = os.getenv("CESTT_MANIFEST")
+    if env_path:
+        p = Path(env_path).expanduser()
+        if p.is_file():
+            yield p
+
+    if not engine_path:
+        return
+
+    engine = Path(engine_path)
+    # Same directory with additional suffixes.
+    yield engine.with_suffix(engine.suffix + ".cestt.json")
+    yield engine.with_suffix(engine.suffix + ".cestt")
+    # Same name with JSON extension.
+    yield engine.parent / f"{engine.name}.cestt.json"
+    yield engine.parent / f"{engine.stem}.cestt.json"
+    # Generic manifests inside the directory.
+    yield engine.parent / "cestt_manifest.json"
+    yield engine.parent / "cestt-instrumentation.json"
+
+
+def _load_manifest(path: Path) -> Dict[str, Any]:
+    text = path.read_text(encoding="utf-8", errors="ignore")
+    try:
+        data = json.loads(text)
+        if not isinstance(data, dict):
+            raise ValueError("manifest root must be an object")
+        return data
+    except json.JSONDecodeError:
+        # Support a very small "key=value" manifest for ease of integration.
+        data: Dict[str, Any] = {}
+        for line in text.splitlines():
+            line = line.strip()
+            if not line or line.startswith(("#", ";")):
+                continue
+            if "=" in line:
+                key, value = line.split("=", 1)
+                data[key.strip()] = value.strip()
+        if data:
+            return data
+        raise
+
+
+@dataclass
+class InstrumentationProfile:
+    """Metadata describing the detected instrumentation package."""
+
+    manifest_path: Optional[Path] = None
+    manifest: Dict[str, Any] = field(default_factory=dict)
+    error: Optional[str] = None
+    warnings: List[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        caps = self.manifest.get("capabilities", {})
+        if not isinstance(caps, dict):
+            caps = {}
+        self.capabilities: Dict[str, Any] = dict(caps)
+
+        handshake = self.manifest.get("handshake", {})
+        if not isinstance(handshake, dict):
+            handshake = {}
+        self.handshake_options: Dict[str, Any] = dict(handshake.get("options", {}))
+        self.handshake_commands: List[str] = list(handshake.get("commands", []))
+
+        token = handshake.get("token") or self.manifest.get("token")
+        if token and "token" not in self.handshake_options:
+            # Expose token both in meta and as an option helper.
+            self.handshake_options.setdefault("CESTT Instrumentation Token", token)
+        self.token = token
+
+        self.probes: Dict[str, str] = dict(self.manifest.get("probes", {}))
+        self.assembly_map: List[Dict[str, Any]] = list(self.manifest.get("assembly_map", []))
+        suites = self.manifest.get("pro_tests", {})
+        if isinstance(suites, list):
+            suites = {name: {} for name in suites}
+        if not isinstance(suites, dict):
+            suites = {}
+        self.pro_suites: Dict[str, Any] = suites
+
+        self.trace_pipe: Optional[str] = self.manifest.get("trace_pipe")
+        self.trace_preview_bytes: int = int(self.manifest.get("trace_preview_bytes", 4096))
+
+        self.package = self.manifest.get("package")
+        self.version = self.manifest.get("version")
+
+        self.available: bool = bool(
+            self.capabilities.get("assembly_debug")
+            or self.capabilities.get("professional")
+            or self.capabilities.get("pro_tests")
+            or self.pro_suites
+        )
+
+    # ------------------------------------------------------------------ helpers
+    def describe(self) -> str:
+        if not self.manifest:
+            return "no instrumentation"
+        base = self.package or "unnamed package"
+        if self.version:
+            base = f"{base} v{self.version}"
+        if self.token:
+            base = f"{base} (token={self.token})"
+        return base
+
+    def to_report_dict(self) -> Dict[str, Any]:
+        return {
+            "detected": bool(self.manifest),
+            "available": self.available,
+            "manifest": str(self.manifest_path) if self.manifest_path else None,
+            "package": self.package,
+            "version": self.version,
+            "capabilities": self.capabilities,
+            "pro_suites": list(self.pro_suites.keys()),
+            "warnings": list(self.warnings),
+            "error": self.error,
+        }
+
+    # Capabilities ------------------------------------------------------------
+    def supports_assembly_debug(self) -> bool:
+        return bool(self.capabilities.get("assembly_debug"))
+
+    def supports_professional_suite(self) -> bool:
+        return bool(self.capabilities.get("professional") or self.pro_suites)
+
+    @property
+    def uci_options(self) -> Dict[str, Any]:
+        return dict(self.handshake_options)
+
+    def activate(self, runner: Any, logger: Optional[Any] = None) -> None:
+        """Send handshake commands to an already running :class:`EngineRunner`.
+
+        The runner is expected to expose a ``send_command`` method.  Any errors
+        are captured inside ``self.warnings`` so the caller can surface them to
+        the user.
+        """
+
+        for cmd in self.handshake_commands:
+            try:
+                runner.send_command(cmd)
+                if logger:
+                    logger.log(f"[instrumentation] → {cmd}")
+            except Exception as exc:  # pragma: no cover - defensive
+                msg = f"handshake command '{cmd}' failed: {exc!r}"
+                self.warnings.append(msg)
+                if logger:
+                    logger.log(f"[instrumentation] {msg}")
+
+    # Trace utilities --------------------------------------------------------
+    def capture_trace_preview(self) -> str:
+        if not self.trace_pipe:
+            return ""
+        path = Path(self.trace_pipe)
+        if not path.exists() or not path.is_file():
+            self.warnings.append(f"trace pipe '{path}' not found")
+            return ""
+        try:
+            data = path.read_bytes()
+        except Exception as exc:  # pragma: no cover - filesystem race
+            self.warnings.append(f"trace read failed: {exc!r}")
+            return ""
+        if not data:
+            return ""
+        if len(data) > self.trace_preview_bytes:
+            data = data[-self.trace_preview_bytes :]
+        return data.decode("utf-8", errors="replace")
+
+    def get_suite(self, name: str, default: Any = None) -> Any:
+        return self.pro_suites.get(name, default)
+
+
+def detect(engine_path: Optional[str]) -> InstrumentationProfile:
+    last_error: Optional[str] = None
+    for candidate in _iter_candidates(engine_path):
+        if not candidate.exists():
+            continue
+        try:
+            manifest = _load_manifest(candidate)
+        except Exception as exc:  # pragma: no cover - malformed manifest
+            last_error = f"failed to load {candidate}: {exc}"
+            continue
+        return InstrumentationProfile(candidate, manifest)
+
+    if os.getenv("CESTT_ADVANCED", "").strip():
+        manifest = {
+            "package": "environment override",
+            "version": "env",
+            "capabilities": {"assembly_debug": True, "professional": True},
+        }
+        profile = InstrumentationProfile(None, manifest)
+        profile.warnings.append("CESTT_ADVANCED environment flag forced enable")
+        return profile
+
+    profile = InstrumentationProfile(None, {})
+    profile.error = last_error
+    return profile
+


### PR DESCRIPTION
## Summary
- add an instrumentation detection layer that reads manifest data and exposes handshake utilities
- wire instrumentation awareness through EngineRunner, CLI/GUI, and the existing stress tests so manifests unlock extra functionality
- introduce new assembly-debug and professional suite test modules that run when advanced instrumentation is available

## Testing
- python -m compileall CESTT

------
https://chatgpt.com/codex/tasks/task_e_68c931bb3d6c83309c91a7edc2906224